### PR TITLE
Fix LinkedIn Community Guidelines

### DIFF
--- a/declarations/LinkedIn.history.json
+++ b/declarations/LinkedIn.history.json
@@ -1,0 +1,15 @@
+{
+  "Community Guidelines": [
+    {
+      "fetch": "https://fr.linkedin.com/legal/professional-community-policies",
+      "select": [
+        "main"
+      ],
+      "remove": [
+        ".banner__image-container",
+        ".component-standaloneImage"
+      ],
+      "validUntil": "2022-03-16T16:02:30+01:00"
+    }
+  ]
+}

--- a/declarations/LinkedIn.json
+++ b/declarations/LinkedIn.json
@@ -19,7 +19,7 @@
       ]
     },
     "Community Guidelines": {
-      "fetch": "https://fr.linkedin.com/legal/professional-community-policies",
+      "fetch": "https://www.linkedin.com/legal/professional-community-policies",
       "select": [
         "main"
       ],


### PR DESCRIPTION
Previous fetch url `https://fr.linkedin.com/legal/professional-community-policies` redirect to `https://www.linkedin.com/legal/professional-community-policies` which is an english document.

Fr the moment I have not found a way to retrieve the french document.