### PR TITLE
Update selectors

### DIFF
--- a/declarations/LinkedIn.json
+++ b/declarations/LinkedIn.json
@@ -8,7 +8,7 @@
       ],
       "remove": [
         ".callout > svg",
-        ".expandable-section__header",
+        "[aria-controls=\"expandableSection\"]",
         ".banner__image-container "
       ]
     },


### PR DESCRIPTION
Fix https://github.com/OpenTermsArchive/france-elections-versions/commit/233e5e799b3c7ba9618b142349c2cb5978e9e6cd
No need for history as these selectors were also valid for previous snapshots